### PR TITLE
added deprecation note regarding Cat v5.90013

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.16  Fri, 22, June 2010 09:13:00 +0500
+  * Updated documentation to let people know this has been merged into the
+    recent 5.90013 version of Catalyst, and therefore it is considered
+    deprecated for new development and only remains for legacy / historical
+    reasons.
+
 0.15  Thu, 26 Aug 2010 00:22:42 +0200
   * Improvements to documentation (William King, Tomas Doran)
   * Don't apply roles to special internal catalyst actions

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = Catalyst-Controller-ActionRole
-version = 0.15
+version = 0.16
 author  = Florian Ragwitz <rafl@debian.org>
 author  = Hans Dieter Pearcey <hdp@weftsoar.net>
 author  = Alex J. G. Burzyński <ajgb@ajgb.net>

--- a/lib/Catalyst/Controller/ActionRole.pm
+++ b/lib/Catalyst/Controller/ActionRole.pm
@@ -1,5 +1,5 @@
 package Catalyst::Controller::ActionRole;
-# ABSTRACT: Apply roles to action instances
+# ABSTRACT: [DEPRECATED] Apply roles to action instances
 
 use Moose;
 use Class::MOP;
@@ -23,6 +23,12 @@ extends 'Catalyst::Controller';
     BEGIN { extends 'Catalyst::Controller::ActionRole' }
 
     sub bar : Local Does('Moo') { ... }
+
+=head1 DEPRECATION
+
+As of version C<5.90013>, L<Catalyst> has merged this functionality into the
+core L<Catalyst::Controller>.  You should no longer use it for new development
+and we'd recommend switching to the core controller as you can when you upgrade.
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Hey,  I updated this with a short note to let users know to start moving code to catalyst core when possible.  Here's a tar ball that looks good to me, ready for you to send to cpan, if you agree :)

https://dl.dropbox.com/u/2605244/Catalyst-Controller-ActionRole-0.16.tar.gz
